### PR TITLE
Correct unsigned two's-complement range formula

### DIFF
--- a/src/bgc_part_1000_types_2.md
+++ b/src/bgc_part_1000_types_2.md
@@ -116,7 +116,7 @@ OK, now, finally, we can figure out the range of numbers if we assume
 that a `char` is 8 bits and your system uses the virtually universal
 two's complement representation for signed and unsigned^[In general, f
 you have an $n$ bit two's complement number, the signed range is
-$-2^{n-1}$ to $2^{n-1}-1$. And the unsigned range is $0$ to $2^{n-1}$.].
+$-2^{n-1}$ to $2^{n-1}-1$. And the unsigned range is $0$ to $2^n-1$.].
 
 So, assuming those constraints, we can finally figure our ranges:
 


### PR DESCRIPTION
Applied example:
```
2^{8-1} == 128 (current formula)
2^8-1   == 255 (corrected formula)
```