### PR TITLE
Fix typo

### DIFF
--- a/src/bgc_part_0200_var_stat.md
+++ b/src/bgc_part_0200_var_stat.md
@@ -831,7 +831,7 @@ int main(void)
             break;
 
         case 1:
-            printf("You have a singular goat.\n");
+            printf("You have a single goat.\n");
             break;
 
         case 2:


### PR DESCRIPTION
I'm not completely sure on this one, but according to [this](https://www.lawprose.org/garners-usage-tip-of-the-day-single-singular/), it should be "single".