### PR TITLE
pass into func() -> pass to func()

### DIFF
--- a/src/bgc_part_0500_arrays.md
+++ b/src/bgc_part_0500_arrays.md
@@ -468,7 +468,7 @@ But if the function has a pointer to the data, it is able to manipulate
 that data! So changes that a function makes to an array will be visible
 back out in the caller.
 
-Here's an example where we pass a pointer to an array into a function,
+Here's an example where we pass a pointer to an array to a function,
 the function manipulates the values in that array, and those changes are
 visible out in the caller.
 

--- a/src/bgc_part_0500_arrays.md
+++ b/src/bgc_part_0500_arrays.md
@@ -67,7 +67,7 @@ it separately in another variable.
 When I say "can't", I actually mean there are some circumstances when
 you _can_. There is a trick to get the number of elements in an array in
 the scope in which an array is declared. But, generally speaking, this
-won't work the way you want if you pass the array into a
+won't work the way you want if you pass the array to a
 function^[Because when you pass an array to a function, you're actually
 just passing a pointer to the first element of that array, not the
 "entire" array.].

--- a/src/bgc_part_1100_types_3.md
+++ b/src/bgc_part_1100_types_3.md
@@ -201,7 +201,7 @@ int main(void)
 
 So there we have `strtoul()` modifying what `badchar` points to in order
 to show us where things went wrong^[We have to pass a pointer to
-`badchar` into `strtoul()` or it won't be able to modify it in any way
+`badchar` to `strtoul()` or it won't be able to modify it in any way
 we can see, analogous to why you have to pass a pointer to an `int` to a
 function if you want that function to be able to change that value of
 that `int`.].

--- a/src/bgc_part_1600_structs2.md
+++ b/src/bgc_part_1600_structs2.md
@@ -474,7 +474,7 @@ field^[`super` isn't a keyword, incidentally. I'm just stealing some OOP
 terminology.].
 
 Let's set up an example here. We'll make `struct`s as above, but then
-we'll pass a pointer to a `struct child` into a function that needs a
+we'll pass a pointer to a `struct child` to a function that needs a
 pointer to a `struct parent`... and it'll still work.
 
 ``` {.c .numberLines}

--- a/src/bgc_part_2500_vla.md
+++ b/src/bgc_part_2500_vla.md
@@ -218,7 +218,7 @@ Same thing as we did with the second form of one-dimensional VLAs,
 above, but this time we're passing in two dimensions and using those.
 
 In the following example, we build a multiplication table matrix of a
-variable width and height, and then pass it into a function to print it
+variable width and height, and then pass it to a function to print it
 out.
 
 ``` {.c .numberLines}

--- a/src/bgc_part_2900_jmp.md
+++ b/src/bgc_part_2900_jmp.md
@@ -90,7 +90,7 @@ So here's the deal: if `setjmp()` returns `0`, it means that you've
 successfully set the "bookmark" at that point.
 
 If it returns non-zero, it means you've just returned to the "bookmark"
-set earlier. (And the value returned is the one you pass into
+set earlier. (And the value returned is the one you pass to
 `longjmp()`.)
 
 This way you can tell the difference between setting the bookmark and

--- a/src/bgc_part_3400_threads.md
+++ b/src/bgc_part_3400_threads.md
@@ -334,7 +334,7 @@ int main(void)
 
 Notice on lines 27-30 we `malloc()` space for an `int` and copy the
 value of `i` into it. Each new thread gets its own freshly-`malloc()`d
-variable and we pass a pointer to that into the `run()` function.
+variable and we pass a pointer to that to the `run()` function.
 
 Once `run()` makes its own copy of the `arg` on line 7, it `free()`s the
 `malloc()`d `int`. And now that it has its own copy, it can do with it

--- a/src/bgc_part_3400_threads.md
+++ b/src/bgc_part_3400_threads.md
@@ -1237,5 +1237,5 @@ int run(void *arg)
     // ...
 ```
 
-In this example, no matter how many threads get into the `run()`
+In this example, no matter how many threads get to the `run()`
 function, the `run_once_function()` will only be called a single time.

--- a/src/bgc_part_5200_man_math.md
+++ b/src/bgc_part_5200_man_math.md
@@ -109,7 +109,7 @@ long double powl(long double x, long double y);  // long double
 ```
 
 Remember that parameters are given values as if you assigned into them.
-So if you pass a `double` into `powf()`, it'll choose the closest
+So if you pass a `double` to `powf()`, it'll choose the closest
 `float` it can to hold the double. If the `double` doesn't fit,
 undefined behavior happens.
 

--- a/src/misc.md
+++ b/src/misc.md
@@ -1358,7 +1358,7 @@ interchanging `int`s and `enum`s.
 We'll be all happy and C-like here, though.)
 
 Note that an `enum` is a type, too. You can
-`typedef` it, you can pass them into functions, and
+`typedef` it, you can pass them to functions, and
 so on, again, just like "normal" types.
 
 Here are some enums and their usage. Remember---treat them just


### PR DESCRIPTION
Not sure if this is correct.
"Pass to" just sounds more correct to me, and it's also used many times throughout the book. 