### PR TITLE
fix typos

### DIFF
--- a/src/bgc_part_1400_env.md
+++ b/src/bgc_part_1400_env.md
@@ -496,7 +496,7 @@ $ ./foo
 Cannot find the FROTZ environment variable
 ```
 
-which makes since, since I haven't set it yet.
+which makes sense, since I haven't set it yet.
 
 In bash, I can set it to something with^[In Windows CMD.EXE, use `set
 FROTZ=value`. In PowerShell, use `$Env:FROTZ=value`.]:

--- a/src/bgc_part_1600_structs2.md
+++ b/src/bgc_part_1600_structs2.md
@@ -946,7 +946,7 @@ So far, nothing special has happened here. It seems like the `type`
 field is completely useless.
 
 But now let's make a generic function that prints a `union animal`. It
-has to someone be able to tell if it's looking at a `struct antelope` or
+has to somehow be able to tell if it's looking at a `struct antelope` or
 a `struct octopus`.
 
 Because of the magic of common initial sequences, it can look up the


### PR DESCRIPTION
Also, there seems to be a Markdown-related issue with the redirection to the `static` and `extern` section, at the end of the subsection _13.2 File Scope_