### PR TITLE
Fix code formatting typo.

### DIFF
--- a/src/bgc_part_1200_types_4.md
+++ b/src/bgc_part_1200_types_4.md
@@ -65,7 +65,8 @@ Somewhat confusingly, these two things are equivalent:
 
 ``` {.c}
 const int *p;  // Can't modify what p points to
-int const *p;  // Can't modify what p points to, just like the previous line ```
+int const *p;  // Can't modify what p points to, just like the previous line
+```
 
 Great, so we can't change the thing the pointer points to, but we can
 change the pointer itself. What if we want the other way around? We want


### PR DESCRIPTION
There's a missing new line at the end of a code block, causing the next paragraph to render as code.