### PR TITLE
fix wrong ordering

### DIFF
--- a/src/bgc_part_3490_atomics.md
+++ b/src/bgc_part_3490_atomics.md
@@ -368,7 +368,7 @@ With read/load/acquire of a particular atomic variable:
 
 * The acquire acts as a one-way barrier when it comes to code
   reordering; reads and writes in the current thread can be moved down
-  from _after_ the release to _before_ it. But, more importantly for
+  from _before_ the release to _after_ it. But, more importantly for
   synchronization, nothing can move down from _after_ the acquire to
   _before_ it.
 


### PR DESCRIPTION
`The acquire acts as a one-way barrier when it comes to code
  reordering; reads and writes in the current thread can be moved down
  from _after_ the release to _before_ it. But, more importantly for
  synchronization, nothing can move down from _after_ the acquire to
  _before_ it.` doesn't make sense.

 I think the first one is the other way around.

ironic if you ask me xD