### PR TITLE
Fix broken table in Types II

### DIFF
--- a/src/bgc_part_1000_types_2.md
+++ b/src/bgc_part_1000_types_2.md
@@ -369,6 +369,7 @@ take, but on my system, we can see the relative size increases:
 
 [i[`double` type]<]
 [i[`long double` type]<]
+
 |Type|`sizeof`|
 |:-|-:|
 |`float`|4|


### PR DESCRIPTION
A missing newline is causing a table in section 14.4 (chapter Types II) to not render correctly. Here's what it looks like on [the live site](https://beej.us/guide/bgc/html/split/types-ii-way-more-types.html):
![boken-table](https://user-images.githubusercontent.com/3781734/210116101-f66b93da-2e2a-4cc3-b3a8-c16ccd32adb5.png)

Here's the fixed table, rendered locally on my machine:
![fixed-table](https://user-images.githubusercontent.com/3781734/210116127-5e8a8145-e712-42a6-a9c6-7239b36a320f.png)