### PR TITLE
Fix C2x version (C21 -> C23)

### DIFF
--- a/src/bgc_part_0150_intro.md
+++ b/src/bgc_part_0150_intro.md
@@ -338,7 +338,7 @@ But here's a more complete table:
 |**C99**|The first big overhaul with lots of language additions. The thing most people remember is the addition of `//`-style comments. This is the most popular version of C in use as of this writing.|
 |**C11**|This major version update includes Unicode support and multi-threading. Be advised that if you start using these language features, you might be sacrificing portability with places that are stuck in C99 land. But, honestly, 1999 is getting to be a while back now.|
 |C17, C18|Bugfix update to C11. C17 seems to be the official name, but the publication was delayed until 2018. As far as I can tell, these two are interchangeable, with C17 being preferred.|
-|C2x|What's coming next! Expected to eventually become C21.|
+|C2x|What's coming next! Expected to eventually become C23.|
 
 [i[`gcc` compiler]<]You can force GCC to use one of these standards with the
 `-std=` command line argument. If you want it to be picky about the


### PR DESCRIPTION

C2x will be C23.  (__STDC_VERSION__ = 202311L)

See document n3054.pdf.
https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3054.pdf#page=207


--
Regards ... Detlef