### PR TITLE
fix memcpy arguments' description

### DIFF
--- a/src/bgc_part_0800_pointers_2.md
+++ b/src/bgc_part_0800_pointers_2.md
@@ -345,8 +345,8 @@ Let's look at an example, the built-in `memcpy()` function:
 void *memcpy(void *s1, void *s2, size_t n);
 ```
 
-This function copies `n` bytes of memory starting from address `s1` into
-the memory starting at address `s2`.
+This function copies `n` bytes of memory starting from address `s2` into
+the memory starting at address `s1`.
 
 But look! `s1` and `s2` are `void*`s! Why? What does it mean? Let's run
 more examples to see.


### PR DESCRIPTION
As per,

`void *memcpy(void *s1, void *s2, size_t n);`

memcpy copies bytes starting from address 's2' into address 's1'.

The description in lines 348/349 described the opposite.