### PR TITLE
6-3 misleading error

### DIFF
--- a/src/bgc_part_0500_arrays.md
+++ b/src/bgc_part_0500_arrays.md
@@ -146,9 +146,6 @@ int main(void)
 }
 ```
 
-Catch: initializer values must be constant terms. Can't throw variables
-in there. Sorry, Illinois!
-
 You should never have more items in your initializer than there is room
 for in the array, or the compiler will get cranky:
 


### PR DESCRIPTION
Counterexample:

`6-3.c`
```
#include <stdio.h>

int main(void){
    int i;
    int x; // Doesn't even need to be initialized! Merely, declared.
    int a[5] = {1, x, 100, 1000, 10000};
    for (i = 0; i < 5; i++){
        printf("a[%d]: %d\n", i, a[i]);
    }
}
```

Compiled with: 
```$ clang -std=c89 6-3.c -o tmp_binary```

Output:
```
$ ./tmp_binary
a[0]: 1
a[1]: -1752439866
a[2]: 100
a[3]: 1000
a[4]: 10000
```

I also verified this same behavior while compiling with the gnu89, gnu99 & gnu17 standards.

PS: thanks for the incredible resource! It's much appreciated :)

