### PR TITLE
String literals

### DIFF
--- a/src/bgc_part_0600_strings.md
+++ b/src/bgc_part_0600_strings.md
@@ -123,9 +123,9 @@ char *s = "Hello, world!";
 char t[] = "Hello, again!";
 ```
 
-But these two initializations are subtly different. A string literal, similar to an integer literal, has it's memory automatically managed by the compiler for you! With an integer, i.e. a fixed size piece of data, the compiler can pretty easily manage it. But strings are a variable-byte beast which the compiler tames them by tossing into a chunk of memory, and giving you a pointer to it.
+But these two initializations are subtly different. A string literal, similar to an integer literal, has it's memory automatically managed by the compiler for you! With an integer, i.e. a fixed size piece of data, the compiler can pretty easily manage it. But strings are a variable-byte beast which the compiler tames by tossing into a chunk of memory, and giving you a pointer to it.
 
-This form points to wherever that string was placed. Typically, that place is in a faraway land from the rest of your program's memory -- read-only memory for reasons related to performance & safety.
+This form points to wherever that string was placed. Typically, that place is in a land faraway from the rest of your program's memory -- read-only memory -- for reasons related to performance & safety.
 
 ``` {.c}
 char *s = "Hello, world!";

--- a/src/bgc_part_0600_strings.md
+++ b/src/bgc_part_0600_strings.md
@@ -142,8 +142,8 @@ s[0] = 'z';  // BAD NEWS: tried to mutate a string literal!
 The behavior is undefined. Probably, depending on your system, a crash
 will result.
 
-But declaring it as an array is different. The compiler doesn't stow those bytes in another part of town, they're right down the street. Specifically, this one is a mutable _copy_
-of the string that we can change at will:
+But declaring it as an array is different. The compiler doesn't stow those bytes in another part of town, they're right down the street. This one is a mutable _copy_
+of the string -- one we can change at will:
 
 ``` {.c}
 char t[] = "Hello, again!";  // t is an array copy of the string 

--- a/src/bgc_part_0600_strings.md
+++ b/src/bgc_part_0600_strings.md
@@ -123,16 +123,15 @@ char *s = "Hello, world!";
 char t[] = "Hello, again!";
 ```
 
-But these two are subtly different.
+But these two initializations are subtly different. A string literal, similar to an integer literal, has it's memory automatically managed by the compiler for you! With an integer, i.e. a fixed size piece of data, the compiler can pretty easily manage it. But strings are a variable-byte beast which the compiler tames them by tossing into a chunk of memory, and giving you a pointer to it.
 
-This one is a pointer to a string literal (i.e. a pointer to the first
-character in a string):
+This form points to wherever that string was placed. Typically, that place is in a faraway land from the rest of your program's memory -- read-only memory for reasons related to performance & safety.
 
 ``` {.c}
 char *s = "Hello, world!";
 ```
 
-If you try to mutate that string with this:
+So, if you try to mutate that string with this:
 
 ``` {.c}
 char *s = "Hello, world!";
@@ -143,7 +142,7 @@ s[0] = 'z';  // BAD NEWS: tried to mutate a string literal!
 The behavior is undefined. Probably, depending on your system, a crash
 will result.
 
-But declaring it as an array is different. This one is a mutable _copy_
+But declaring it as an array is different. The compiler doesn't stow those bytes in another part of town, they're right down the street. Specifically, this one is a mutable _copy_
 of the string that we can change at will:
 
 ``` {.c}


### PR DESCRIPTION
I've been mostly progressing through the textbook serially (i.e. chapter 1 then 2, then 3, etc.), and got pretty confused at the end of section 7.4. 

It was so bewildering to me that strings, which are so similar to arrays and pointers, can't be modified depending on the style of the initialization. I dug for a while and discovered this is largely due to the ability to express strings as literals, something which can't be done for arrays! And, how the compiler handles those literals.
https://c-faq.com/decl/strlitinit.html

I tried to add a section to explain why that's the case without leveraging any ideas a newer reader who's been reading serially may not have covered yet, such as memory segments (i.e. stack, heap, instruction).

```
int arr1[] = {1,2,3};
char str1[] = {'a', 'b', 'c'};
    
// Note: arr2 & str2 are pointers to 0x1 and the ASCII-decode of the character ‘a’ — 0x61 or 97. 
int *arr2 = {1,2,3};
char *str2 = {'a', 'b', 'c'};

// No equivalent way to do this for arrays!
char *str3 = "abc";
```