### PR TITLE
Use em dash to avoid ambiguity

### DIFF
--- a/src/bgc_part_0200_var_stat.md
+++ b/src/bgc_part_0200_var_stat.md
@@ -448,7 +448,7 @@ a <= b;  // True if a is less than or equal to b
 a >= b;  // True if a is greater than or equal to b
 ```
 
-Don't mix up assignment `=` with comparison `==`! Use two equals to
+Don't mix up assignment `=` with comparison `==` — use two equals to
 compare, one to assign.
 
 We can use the comparison expressions with `if` statements:


### PR DESCRIPTION
It's a little hard to notice that the exclamation mark in `==`! is for emphasis (i.e., punctuation) and not part of the operator. I've used an em dash to make the sentence a little less ambiguous. I considered a semi-colon (`;`), but that'd have the same issue.