### PR TITLE
Add missing comma in src/bgc_part_1800_enum.md

### DIFF
--- a/src/bgc_part_1800_enum.md
+++ b/src/bgc_part_1800_enum.md
@@ -86,7 +86,7 @@ enum {
   C=4,  // 4, manually set
   D,    // 5
   E,    // 6
-  F=3   // 3, manually set
+  F=3,  // 3, manually set
   G,    // 4
   H     // 5
 }


### PR DESCRIPTION
This commit fixes a typo in one of the examples.