### PR TITLE
Fix typo

### DIFF
--- a/src/bgc_part_1900_ptrptr.md
+++ b/src/bgc_part_1900_ptrptr.md
@@ -364,8 +364,8 @@ AB  |
 BF  | padding bytes with "random" value
 26  |
 
-78  |
-56  | x.b == 0x12345678
+78  | x.b == 0x12345678
+56  |
 34  |
 12  |
 ```


### PR DESCRIPTION
it looks like `x.b` is in the wrong place.