### PR TITLE
Changed the value printed from i to *p

### DIFF
--- a/src/bgc_part_0400_pointers.md
+++ b/src/bgc_part_0400_pointers.md
@@ -308,7 +308,7 @@ int main(void)
     *p = 20; // the thing p points to (namely i!) is now 20!!
 
     printf("i is %d\n", i);   // prints "20"
-    printf("i is %d\n", *p);  // "20"! dereference-p is the same as i!
+    printf("*p is %d\n", *p);  // "20"! dereference-p is the same as i!
 }
 ```
 


### PR DESCRIPTION
When printing out the value of the variable i and the pointer p, values are correct but the text outputted on the terminal is for i in both instances. Changed the latter to *p

How it was(change will be on line 14):
![Screenshot From 2025-05-05 09-22-50](https://github.com/user-attachments/assets/d927e5c8-70ba-4056-8649-ce3c5acb9bc2)

Change made:
![Screenshot From 2025-05-05 09-34-50](https://github.com/user-attachments/assets/75ccfd87-9781-49e7-abfc-31ab76b1d2af)
