### PR TITLE
Unnecessary long size of string

### DIFF
--- a/source/examples/strings_strcpy.c
+++ b/source/examples/strings_strcpy.c
@@ -4,7 +4,7 @@
 int main(void)
 {
     char s[] = "Hello, world!";
-    char t[100];  // Each char is one byte, so plenty of room
+    char t[strlen(s)];  // Just enough memory to store the copied string
 
     // This makes a copy of the string!
     strcpy(t, s);


### PR DESCRIPTION
Since strlen lesson was right before the strcpy lesson, it makes sense to use strlen in this example to reinforce