### PR TITLE
14.2: Minor clarity suggestions

### DIFF
--- a/src/bgc_part_1000_types_2.md
+++ b/src/bgc_part_1000_types_2.md
@@ -199,13 +199,13 @@ types. And we learned that `char` was secretly a small `int` in
 disguise. So we know the `int`s can come in multiple bit sizes.
 
 But there are a couple more integer types we should look at, and the
-_minimum_ minimum and maximum values they can hold.
+_minimum_ maximum (and _maximum_ minimum) values they can hold.
 
-Yes, I said "minimum" twice. The spec says that these types will hold
-numbers of _at least_ these sizes, so your implementation might be
-different. The header file `<limits.h>` defines macros that hold the
-minimum and maximum integer values; rely on that to be sure, and _never
-hardcode or assume these values_.
+Yes, I said "minimum maximum". The spec says that these
+types will hold numbers of _at least_ (and _at most_) these sizes, so
+your implementation might be different. The header file `<limits.h>`
+defines macros that hold the minimum and maximum integer values;
+rely on that to be sure, and _never hardcode or assume these values_.
 
 [i[`short` type]<]
 [i[`long` type]<]

--- a/src/bgc_part_1000_types_2.md
+++ b/src/bgc_part_1000_types_2.md
@@ -203,9 +203,9 @@ _minimum_ maximum (and _maximum_ minimum) values they can hold.
 
 Yes, I said "minimum maximum". The spec says that these
 types will hold numbers of _at least_ (and _at most_) these sizes, so
-your implementation might be different. The header file `<limits.h>`
-defines macros that hold the minimum and maximum integer values;
-rely on that to be sure, and _never hardcode or assume these values_.
+your implementation might be more capable or accommodating. The header
+file `<limits.h>`defines macros that hold the minimum and maximum integer
+values; rely on that to be sure, and _never hardcode or assume these values_.
 
 [i[`short` type]<]
 [i[`long` type]<]

--- a/src/bgc_part_1000_types_2.md
+++ b/src/bgc_part_1000_types_2.md
@@ -203,7 +203,7 @@ _minimum_ maximum (and _maximum_ minimum) values they can hold.
 
 Yes, I said "minimum maximum". The spec says that these
 types will hold numbers of _at least_ (and _at most_) these sizes, so
-your implementation might be more capable or accommodating. The header
+your implementation might be more capable (but not less!). The header
 file `<limits.h>`defines macros that hold the minimum and maximum integer
 values; rely on that to be sure, and _never hardcode or assume these values_.
 


### PR DESCRIPTION
A few minor tweaks that I hope improve clarity!

Technically, I think it should be the "minimum maximum" and vice versa. I think the reasoning is clearer in that first case: the minimum maximum value a type can hold (the smallest of all possible maximums across all implementations). The converse is less intuitively clear I think which is why I chose to do it in parentheses each time. 