### PR TITLE
Fix incorrect line number in the VLA chapter

### DIFF
--- a/src/bgc_part_2500_vla.md
+++ b/src/bgc_part_2500_vla.md
@@ -83,7 +83,7 @@ int main(void)
 }
 ```
 
-(On line 7, I have an `fflush()` that should force the line to output
+(On line 8, I have an `fflush()` that should force the line to output
 even though I don't have a newline at the end.)
 
 Line 12 is where we declare the VLA---once execution gets past that


### PR DESCRIPTION
Tiny fix. The `fflush()` call is on line 8, not 7.

<img width="1436" height="458" alt="image" src="https://github.com/user-attachments/assets/a1bc1dad-9fd2-4ba1-9ba1-b94b81ae94ab" />


